### PR TITLE
Fix incorrect context param value

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -5,7 +5,7 @@
 
     <context-param>
         <param-name>contextConfigLocation</param-name>
-        <param-value>com.boostrdev.SpringBootWeblogicLegacyApplication</param-value>
+        <param-value>com.boostrdev.weblogic.legacy.SpringBootWebLogicLegacyApplication</param-value>
     </context-param>
 
     <listener>


### PR DESCRIPTION
The L in Weblogic is in small caps, and the class has been moved to com.boostrdev.weblogic.legacy package.